### PR TITLE
Version 1.0.0

### DIFF
--- a/PublicDataReader/PublicDataPortal/molit.py
+++ b/PublicDataReader/PublicDataPortal/molit.py
@@ -438,8 +438,9 @@ class Building:
             """
             결과 에러
             """
-            self.logger.error(f"({result_code}) {result_msg}")
-            return
+            _error_message = f"({result_code}) {result_msg}"
+            self.logger.error(_error_message)
+            return _error_message
 
 
     def ChangeCols(self, df, category):

--- a/PublicDataReader/PublicDataPortal/molit.py
+++ b/PublicDataReader/PublicDataPortal/molit.py
@@ -177,12 +177,14 @@ class Transaction:
         df = pd.DataFrame()
         for yearMonth in date_list:
             try:
-                self.logger.info(f"{prod} {trans} {yearMonth} 조회 시작")
+                _info_message = f"{prod} {trans} {yearMonth} 조회 시작"
+                self.logger.info(_info_message)
                 df_ = self.read_data(prod, trans, sigunguCode, yearMonth)
                 df = pd.concat([df, df_], axis=0).reset_index(drop=True)
             except:
-                self.logger.eeror(f"{prod} {trans} {yearMonth} 조회 오류")
-                return
+                _error_message = f"{prod} {trans} {yearMonth} 조회 오류"
+                self.logger.error(_error_message)
+                return _error_message
         return df
 
 
@@ -198,9 +200,10 @@ class Transaction:
             endpoint = self.metaDict[prod][trans]['url']
             columns = self.metaDict[prod][trans]['columns']
         except:
-            self.logger.error(f"{prod} {trans} 참조 오류")
-            return
-        
+            _error_message = f"{prod} {trans} 참조 오류"
+            self.logger.error(_error_message)
+            return _error_message
+
         try:
             # URL
             url=f"""{endpoint}&LAWD_CD={str(sigunguCode)}&DEAL_YMD={str(yearMonth)}&numOfRows=99999"""
@@ -213,8 +216,9 @@ class Transaction:
             items = xmlsoup.findAll("item")
             
         except:
-            self.logger.error(f"Open API 호출 오류")
-            return
+            _error_message = f"HTTP 요청 혹은 파싱 오류"
+            self.logger.error(_error_message)
+            return _error_message
         
         if result_code == "00":
             """
@@ -244,16 +248,17 @@ class Transaction:
                 return df
 
             except:
-                self.logger.error(f"조회 로직 오류")
-                return
+                _error_message = f"전처리 오류"
+                self.logger.error(_error_message)
+                return _error_message
 
         else:
             """
             결과 에러
             """
-            self.logger.error(f"({result_code}) {result_msg}")
-            return 
-
+            _error_message = f"({result_code}) {result_msg} OPEN API 오류 - 코드: {result_code}"
+            self.logger.error(_error_message)
+            return _error_message
 
 class Building:
     """
@@ -374,16 +379,18 @@ class Building:
             parameters = self.metaDict[category]['parameters']
             columns = self.metaDict[category]['columns']
         except:
-            self.logger.error(f"{category} 참조 오류")
-            return
+            _error_message = f"{category} 참조 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
         try:
             params = ""
             for key, value in kwargs.items():
                 params += f"&{key}={value}"
         except:
-            self.logger.error(f"{category} 파라미터 파싱 오류")
-            return
+            _error_message = f"{category} 파라미터 파싱 오류"
+            self.logger.error(_error_message)
+            return _error_message
         
         try:
             # URL
@@ -398,8 +405,9 @@ class Building:
             items = xmlsoup.findAll("item")
 
         except:
-            self.logger.error(f"Open API 호출 오류")
-            return
+            _error_message = f"HTTP 요청 혹은 파싱 오류"
+            self.logger.error(_error_message)
+            return _error_message
         
         if result_code == "00":
             """
@@ -407,7 +415,7 @@ class Building:
             """
             # 데이터프레임 생성
             try:
-                df = pd.DataFrame()
+                df = pd.DataFrame(columns=columns)
                 for item in items:
                     row = {}
                     for col in columns:
@@ -416,23 +424,15 @@ class Building:
                             row[col] = tag.text.strip()
                         except:
                             row[col] = ""
-                    df_ = pd.DataFrame([row])
-                    df = df.append(df_)
-
-                if len(df) != 0:
-                    df = df[columns]
-                    df = self.ChangeCols(df, category)
-                    df.index = range(len(df))
-
-                else:
-                    self.logger.info(f"조회 결과 없음")
-                    df = pd.DataFrame(columns=columns)
-                    df = self.ChangeCols(df, category)
-                    return df
+                    df_ = pd.DataFrame([row])[columns]
+                    df = pd.concat([df, df_], axis=0).reset_index(drop=True)
+                df = self.ChangeCols(df, category)
+                return df
 
             except:
-                self.logger.error(f"조회 로직 오류")
-                return
+                _error_message = f"전처리 오류"
+                self.logger.error(_error_message)
+                return _error_message
 
         else:
             """
@@ -440,8 +440,6 @@ class Building:
             """
             self.logger.error(f"({result_code}) {result_msg}")
             return
-
-        return df
 
 
     def ChangeCols(self, df, category):
@@ -876,6 +874,4 @@ class Building:
         df = df.rename(columns=self.colDict)
 
         return df
-
-
 

--- a/PublicDataReader/PublicDataPortal/semas.py
+++ b/PublicDataReader/PublicDataPortal/semas.py
@@ -162,16 +162,18 @@ class StoreInfo:
             endpoint = self.metaDict[category]['url']
             columns = self.metaDict[category]['columns']
         except:
-            self.logger.error(f"{category} 참조 오류")
-            return
+            _error_message = f"{category} 참조 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
         try:
             params = ""
             for key, value in kwargs.items():
                 params += f"&{key}={value}"
         except:
-            self.logger.error(f"{category} 파라미터 파싱 오류")
-            return
+            _error_message = f"{category} 파라미터 파싱 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
         try:
             # URL
@@ -186,8 +188,9 @@ class StoreInfo:
             items = xmlsoup.findAll("item")
 
         except:
-            self.logger.error(f"OpenAPI 호출 오류")
-            return
+            _error_message = f"HTTP 요청 혹은 파싱 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
         if result_code == "00":
             """
@@ -195,7 +198,7 @@ class StoreInfo:
             """
             # 데이터프레임 생성
             try:
-                df = pd.DataFrame()
+                df = pd.DataFrame(columns=columns)
                 for item in items:
                     row = {}
                     for col in columns:
@@ -204,32 +207,24 @@ class StoreInfo:
                             row[col] = tag.text.strip()
                         except:
                             row[col] = ""
-                    df_ = pd.DataFrame([row])
-                    df = df.append(df_)
-
-                if len(df) != 0:
-                    df = df[columns]
-                    df = self.ChangeCols(df)
-                    df.index = range(len(df))
-
-                else:
-                    self.logger.info(f"조회 결과 없음")
-                    df = pd.DataFrame(columns=columns)
-                    df = self.ChangeCols(df)
-                    return df
+                    df_ = pd.DataFrame([row])[columns]
+                    df = pd.concat([df, df_], axis=0).reset_index(drop=True)
+                df = self.ChangeCols(df)
+                return df
 
             except:
-                self.logger.error(f"조회 로직 오류")
-                return
+                _error_message = f"전처리 오류"
+                self.logger.error(_error_message)
+                return _error_message
 
         else:
             """
             결과 에러
             """
-            self.logger.error(f"({result_code}) {result_msg}")
-            return
+            _error_message = f"({result_code}) {result_msg}"
+            self.logger.error(_error_message)
+            return _error_message
 
-        return df
 
     def ChangeCols(self, df):
         """

--- a/PublicDataReader/Seoul/transportation.py
+++ b/PublicDataReader/Seoul/transportation.py
@@ -68,16 +68,18 @@ class Transportation:
             endpoint = self.metaDict[category]['url']
             columns = self.metaDict[category]['columns']
         except:
-            self.logger.error(f"{category} 참조 오류")
-            return
+            _error_message = f"{category} 참조 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
         try:
             params = ""
             for key, value in kwargs.items():
                 params += f"/{value}"
         except:
-            self.logger.error(f"{category} 파라미터 파싱 오류")
-            return
+            _error_message = f"{category} 파라미터 파싱 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
         try:
             check_code = "INFO-000"
@@ -101,12 +103,13 @@ class Transportation:
                 endIdx += 1000
 
         except:
-            self.logger.error(f"OpenAPI 호출 오류")
-            return
+            _error_message = f"HTTP 요청 혹은 파싱 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
         # 데이터프레임 생성
         try:
-            df = pd.DataFrame()
+            df = pd.DataFrame(columns=columns)
             for item in items:
                 row = {}
                 for col in columns:
@@ -115,26 +118,16 @@ class Transportation:
                         row[col] = tag.text.strip()
                     except:
                         row[col] = ""
-                df_ = pd.DataFrame([row])
-                df = df.append(df_)
+                df_ = pd.DataFrame([row])[columns]
+                df = pd.concat([df, df_], axis=0).reset_index(drop=True)
 
-            if len(df) != 0:
-                df = df[columns]
-                df = self.ChangeCols(df)
-                df.index = range(len(df))
-
-            else:
-                self.logger.info(f"조회 결과 없음")
-                df = pd.DataFrame(columns=columns)
-                df = self.ChangeCols(df)
-                return df
+            df = self.ChangeCols(df)
+            return df
 
         except:
-            self.logger.error(f"조회 로직 오류")
-            return
-
-        return df
-
+            _error_message = f"전처리 오류"
+            self.logger.error(_error_message)
+            return _error_message
 
 
     def ChangeCols(self, df):

--- a/PublicDataReader/config/info.py
+++ b/PublicDataReader/config/info.py
@@ -1,4 +1,4 @@
-__version__ = "2022.7.14.2"
+__version__ = "1.0.0"
 __author__ = "정우일(Wooil Jeong)"
 __contact__ = "wooil@kakao.com"
 __github__ = "https://github.com/WooilJeong/PublicDataReader"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # PublicDataReader
 
+[![PyPI Latest Release](https://img.shields.io/pypi/v/publicdatareader.svg)](https://pypi.org/project/publicdatareader/)
 ![](https://img.shields.io/badge/pandas-1.3.4-red.svg)
 ![](https://img.shields.io/badge/requests-2.26.0-blue.svg)
 ![](https://img.shields.io/badge/beautifulsoup4-4.10.0-yellow.svg)

--- a/create_code_bdong_file.ipynb
+++ b/create_code_bdong_file.ipynb
@@ -7,27 +7,13 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import json"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import json\n",
+    "\n",
     "# 법정동코드 최신 엑셀 파일 데이터프레임으로 로드\n",
     "df = pd.read_excel(\"./PublicDataReader/raw/KIKcd_B.20220701(말소코드포함).xlsx\")\n",
     "# 데이터프레임을 딕셔너리로 변환\n",
-    "df_dict = df.to_dict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "df_dict = df.to_dict()\n",
+    "\n",
     "with open(\"./PublicDataReader/raw/code_bdong.json\", \"w\") as f:\n",
     "    f.write(json.dumps(df_dict))\n",
     "    f.close()"

--- a/develop_test.ipynb
+++ b/develop_test.ipynb
@@ -14,31 +14,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022.07.13\n",
-      "['__version__', '__author__', '__contact__', '__github__', 'Transaction', 'Building', 'StoreInfo', 'Transportation', 'code_bdong']\n"
+      "1.0.0\n"
      ]
     }
    ],
    "source": [
-    "# 1. 라이브러리 임포트 및 버전 확인하기\n",
     "import PublicDataReader as pdr\n",
     "from config import API_KEY_INFO\n",
-    "print(pdr.__version__)"
+    "print(pdr.__version__)\n",
+    "_portal = API_KEY_INFO.get(\"portal\")\n",
+    "_seoul = API_KEY_INFO.get(\"seoul\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# 2. 공공 데이터 포털 OpenAPI 서비스 인증키 입력하기\n",
-    "serviceKey = API_KEY_INFO.get(\"portal\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -47,369 +37,34 @@
      "text": [
       "[INFO] 아파트 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
       "[INFO] 아파트 전월세 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
-      "[ERROR] 오피스텔 매매 조회 서비스 오류 - (99) DEADLINE HAS EXPIRED ERROR.\n",
+      "[INFO] 오피스텔 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
       "[INFO] 오피스텔 전월세 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
-      "[ERROR] 단독다가구 매매 조회 서비스 오류 - (99) SERVICE ACCESS DENIED ERROR.\n",
-      "[ERROR] 단독다가구 전월세 조회 서비스 오류 - (99) DEADLINE HAS EXPIRED ERROR.\n",
-      "[ERROR] 연립다세대 매매 조회 서비스 오류 - (99) DEADLINE HAS EXPIRED ERROR.\n",
-      "[ERROR] 연립다세대 전월세 조회 서비스 오류 - (99) DEADLINE HAS EXPIRED ERROR.\n",
+      "[INFO] 단독다가구 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 단독다가구 전월세 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 연립다세대 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 연립다세대 전월세 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
       "[INFO] 상업업무용 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
-      "[ERROR] 토지 매매 조회 서비스 오류 - (99) DEADLINE HAS EXPIRED ERROR.\n",
-      "[ERROR] 분양입주권 매매 조회 서비스 오류 - (99) DEADLINE HAS EXPIRED ERROR.\n",
-      "[ERROR] 공장창고등 매매 조회 서비스 오류 - (99) SERVICE ACCESS DENIED ERROR.\n"
+      "[INFO] 토지 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 분양입주권 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 공장창고등 매매 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 기본개요 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 총괄표제부 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 표제부 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 층별개요 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 부속지번 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 전유공용면적 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 오수정화시설 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 주택가격 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 전유부 조회 서비스 정상 - (00) NORMAL SERVICE.\n",
+      "[INFO] 지역지구구역 조회 서비스 정상 - (00) NORMAL SERVICE.\n"
      ]
     }
    ],
    "source": [
-    "# 3. 국토교통부 실거래가 정보 조회 OpenAPI 세션 정의하기\n",
-    "# debug: True이면 모든 메시지 출력, False이면 오류 메시지만 출력 (기본값: False)\n",
-    "ts = pdr.Transaction(serviceKey, debug=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T15:42:40.724236Z",
-     "start_time": "2021-11-15T15:42:40.706149Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import PublicDataReader as pdr\n",
-    "from config import OpenAPI\n",
-    "import pandas as pd\n",
-    "import datetime\n",
-    "import logging\n",
-    "import requests\n",
-    "from bs4 import BeautifulSoup\n",
-    "\n",
-    "# DataFrame 디스플레이 설정\n",
-    "pd.set_option('display.max_columns', 250)\n",
-    "pd.set_option('display.max_rows', 250)\n",
-    "pd.set_option('display.width', 100)\n",
-    "\n",
-    "print(pdr.__all__)\n",
-    "print(pdr.__version__)\n",
-    "# print(pdr.__info__)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T15:42:44.269894Z",
-     "start_time": "2021-11-15T15:42:41.391792Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# 공공 데이터 포털 서비스키\n",
-    "serviceKey = OpenAPI['molit']\n",
-    "\n",
-    "# 실거래가\n",
-    "ts = pdr.Transaction(serviceKey, debug=False)\n",
-    "# 건축물대장\n",
-    "bd = pdr.Building(serviceKey, debug=False)\n",
-    "# 상가업소\n",
-    "si = pdr.StoreInfo(serviceKey, debug=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T07:53:08.983369Z",
-     "start_time": "2021-11-15T07:53:08.969351Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# 서울 열린데이터 광장 서비스키\n",
-    "seoulServiceKey = OpenAPI['seoul']\n",
-    "\n",
-    "# 지하철승하차\n",
-    "self = pdr.Transportation(seoulServiceKey, debug=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T07:47:11.642078Z",
-     "start_time": "2021-11-15T07:47:10.881749Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "category = \"지하철승하차\"\n",
-    "date = \"20211101\"\n",
-    "df = self.read_data(category, date=date)\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T07:48:13.374435Z",
-     "start_time": "2021-11-15T07:48:09.162682Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "category = \"버스승하차\"\n",
-    "date = \"20211031\"\n",
-    "df = self.read_data(category, date=date)\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T05:38:39.998208Z",
-     "start_time": "2021-11-15T05:38:39.908212Z"
-    },
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "# 행정구역코드 조회\n",
-    "code = pdr.code_list()\n",
-    "code"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T05:40:59.319237Z",
-     "start_time": "2021-11-15T05:40:57.697225Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# 실거래가 조회\n",
-    "prod = \"아파트\"\n",
-    "trans = \"매매\"\n",
-    "sigunguCode = \"41135\"\n",
-    "startYearMonth = \"202110\"\n",
-    "endYearMonth = \"202111\"\n",
-    "\n",
-    "df = ts.collect_data(prod, trans, sigunguCode, startYearMonth, endYearMonth)\n",
-    "df.tail(1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T05:41:02.393897Z",
-     "start_time": "2021-11-15T05:41:02.221648Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# 건축물대장 조회\n",
-    "category = \"총괄표제부\"\n",
-    "sigunguCd = \"41135\"\n",
-    "bjdongCd = \"11000\"\n",
-    "bun = \"0542\"\n",
-    "ji = \"0000\"\n",
-    "\n",
-    "df = bd.read_data(category=category, sigunguCd=sigunguCd, bjdongCd=bjdongCd, bun=bun, ji=ji)\n",
-    "df.tail(1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-15T05:41:07.786403Z",
-     "start_time": "2021-11-15T05:41:06.973734Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# 상가업소 조회\n",
-    "category = \"지번상가\"\n",
-    "key = '1165010100108120002'\n",
-    "indsLclsCd = 'Q'\n",
-    "\n",
-    "df = si.read_data(category=category, key=key, indsLclsCd=indsLclsCd)\n",
-    "df.tail(1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 컬럼 리스트 추출"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-11-10T08:30:22.486468Z",
-     "start_time": "2021-11-10T08:30:15.941628Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# LAWD_CD=11680\n",
-    "# DEAL_YMD=202110\n",
-    "\n",
-    "\n",
-    "# for prod in ['아파트','오피스텔','단독다가구','연립다세대','상업업무용','분양입주권','토지']:\n",
-    "#     for trans in ['매매', '전월세']:\n",
-    "#         try:\n",
-    "#             print()\n",
-    "#             print(f\">> {prod} {trans}\")\n",
-    "#             print()\n",
-    "#             service_url = self.metaDict[prod][trans]['url']\n",
-    "\n",
-    "#             # URL\n",
-    "#             url=f\"\"\"\\\n",
-    "# {service_url}\\\n",
-    "# &LAWD_CD={str(LAWD_CD)}\\\n",
-    "# &DEAL_YMD={str(DEAL_YMD)}\\\n",
-    "# &numOfRows=99999\\\n",
-    "#             \"\"\"\n",
-    "\n",
-    "#             result = requests.get(url, verify=False)\n",
-    "#             xmlsoup = BeautifulSoup(result.text, \"lxml-xml\")\n",
-    "#             item = xmlsoup.find(\"item\")\n",
-    "\n",
-    "#             col_list = []\n",
-    "#             for i in item:\n",
-    "#                 col_list.append(i.name)\n",
-    "#             for col in col_list: \n",
-    "#                 print(f\"'{col}'\", end=',')\n",
-    "                \n",
-    "#         except:\n",
-    "#             print(\"Error\")\n",
-    "#             pass"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Features\n",
-    "\n",
-    "- 공통\n",
-    "\n",
-    "    - 로깅 기능\n",
-    "        - 세션 초기화 시 `debug` 인자 추가\n",
-    "            - False(Default): 오류 레벨만 출력\n",
-    "            - True: 모든 레벨 출력\n",
-    "        - OPEN API 에러 코드 출력\n",
-    "\n",
-    "    - Air Korea Open API 모듈 제거\n",
-    "    \n",
-    "    - 법정동코드 테이블 조회 함수 추가\n",
-    "\n",
-    "- 부동산 실거래가\n",
-    "\n",
-    "    - 데이터 조회 메서드 일원화\n",
-    "        - molit.read_data('아파트', '매매', '11680', '202111')\n",
-    "            - 서비스별 End-point 및 컬럼 매핑 딕셔너리 추가\n",
-    "    - 데이터 수집 메서드 신규 메서드 추가\n",
-    "        - molit.collect_data('아파트', '매매', '11680', '202101', '202103')\n",
-    "\n",
-    "- 건축물대장\n",
-    "    \n",
-    "    - 데이터 조회 메서드 일원화\n",
-    "        - molit.read_data(category, sigunguCd=sigunguCd, bjdongCd=bjdongCd, bun=bun, ji=ji)\n",
-    "        \n",
-    "- 서울 열린데이터 광장\n",
-    "    - 교통\n",
-    "        - 지하철 호선별 역별 승하차\n",
-    "        - 버스 노선별 정류장별 승하차"
+    "ts = pdr.Transaction(_portal, debug=True)\n",
+    "bd = pdr.Building(_portal, debug=True)\n",
+    "si = pdr.StoreInfo(_portal, debug=True)\n",
+    "se = pdr.Transportation(_seoul, debug=True)"
    ]
   }
  ],


### PR DESCRIPTION
*주요 업데이트 내용*

- '국토교통부_공장 및 창고 등 부동산 매매 신고 자료 조회 서비스' 메서드 추가

- 문자열 데이터를 정수형 데이터로 변환
> '년','월','일','층','건축년도','거래금액','보증금액','보증금','월세금액','월세'

- 문자열 데이터를 실수형 데이터로 변환
> '전용면적','대지권면적','대지면적','연면적','계약면적','건물면적','거래면적'

- API 응답 코드 반환 로직 추가
> 데이터 조회 오류 시 데이터프레임 객체가 아닌 문자열 오류 문구 객체 반환

- DataFrame 병합 방식 변경
> Append() 메서드에서 Concat() 메서드로 변경

- PublicDataReader.code_list() 에서 PublicDataReader.code_bdong() 로 메서드 변경
> 법정동코드 참조 방식 변경 (웹에서 로컬 패키지 경로로 변경)